### PR TITLE
Feature account admin settings

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -12,7 +12,6 @@ use App\Traits\AdminTrait;
 use App\Traits\RecordTrait;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Redis;
 use Illuminate\Validation\Rule;
 
 class AccountController extends Controller

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -12,6 +12,7 @@ use App\Traits\AdminTrait;
 use App\Traits\RecordTrait;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Validation\Rule;
 
 class AccountController extends Controller
@@ -550,9 +551,9 @@ class AccountController extends Controller
         $this->validate($request, [
             'auth_email' => 'bail|required|exists:administrators,email',
             'slug' => 'bail|required|exists:students',
-            'first_name' => 'bail|required|min:2|max:200',
+            'first_name' => 'bail|nullable|min:2|max:200',
             'middle_name' => 'bail|nullable|min:2|max:200',
-            'last_name' => 'bail|required|min:2|max:200',
+            'last_name' => 'bail|nullable|min:2|max:200',
         ]);
 
         try {
@@ -591,9 +592,9 @@ class AccountController extends Controller
                 ]));
             }
 
-            $student->first_name = $request->first_name;
+            $student->first_name = $request->first_name ?? $student->first_name;
             $student->middle_name = $request->middle_name;
-            $student->last_name = $request->last_name;
+            $student->last_name = $request->last_name ?? $student->last_name;
 
             $student->save();
 
@@ -854,6 +855,210 @@ class AccountController extends Controller
             return $this->successResponse("details", $student->only(['first_name', 'middle_name', 'last_name']));
         } catch (\Exception $e) {
             Log::error("Failed to update student's password. " . $e->getMessage() . ".\n");
+            return $this->errorResponse($this->getPredefinedResponse([
+                'type' => 'default',
+            ]));
+        }
+    }
+
+    // Authenticated user
+    public function nameUpdate(Request $request) {
+        Log::info("Entering AccountController nameUpdate...\n");
+
+        $this->validate($request, [
+            'slug' => [
+                'bail',
+                'required',
+                'regex:/^[^\s\[\]\.\|@\^\\\$\?\*\+\(\)\{\}~!#%&`]+?$/',
+            ],
+            'first_name' => 'bail|nullable|min:2|max:200',
+            'middle_name' => 'bail|nullable|min:2|max:200',
+            'last_name' => 'bail|nullable|min:2|max:200',
+        ]);
+
+        try {
+            $admin = $this->getRecord('administrators', $request->slug);
+            $student = $this->getRecord('students', $request->slug);
+            $user = null;
+
+            if (!($admin)) {
+                Log::notice("Administrator does not exist on our system.\n");
+            }
+
+            if (!($student)) {
+                Log::notice("Student does not exist on our system.\n");
+            }
+
+            $user = $admin ? $admin : $student;
+
+            if (!($user)) {
+                Log::notice("User does not exist on our system.\n");
+                return $this->errorResponse($this->getPredefinedResponse([
+                    'type' => 'not-found',
+                    'content' => 'user',
+                ]));
+            }
+
+            $tokenId = $this->getTokenId($request->bearerToken(), $user);
+
+            if (!($tokenId)) {
+                Log::error("Bearer token is missing and/or user-token did not match.\n");
+                return $this->errorResponse($this->getPredefinedResponse([
+                    'type' => 'default',
+                ]));
+            }
+
+            $user->first_name = $request->first_name ?? $user->first_name;
+            $user->middle_name = $request->middle_name;
+            $user->last_name = $request->last_name ?? $user->last_name;
+
+            $user->save();
+
+            Log::info("Successfully updated authenticated user ID " . $user->id . "'s name. Leaving AccountController nameUpdate...\n");
+            return $this->successResponse("details", $user->only(['first_name', 'middle_name', 'last_name']));
+        } catch (\Exception $e) {
+            Log::error("Failed to update authenticated user's name. " . $e->getMessage() . ".\n");
+            return $this->errorResponse($this->getPredefinedResponse([
+                'type' => 'default',
+            ]));
+        }
+    }
+
+    public function emailUpdate(Request $request) {
+        Log::info("Entering AccountController emailUpdate...\n");
+
+        if (!(preg_match('/^[^\s\[\]\.\|@\^\\\$\?\*\+\(\)\{\}~!#%&`]+?$/', $request->slug))) {
+            Log::notice("Slug did not match regex.\n");
+            return $this->errorResponse($this->getPredefinedResponse([
+                'type' => 'default',
+            ]));
+        }
+
+        $admin = $this->getRecord('administrators', $request->slug);
+        $student = $this->getRecord('students', $request->slug);
+        $user = null;
+
+        if (!($admin)) {
+            Log::notice("Administrator does not exist on our system.\n");
+        }
+
+        if (!($student)) {
+            Log::notice("Student does not exist on our system.\n");
+        }
+
+        $user = $admin ? $admin : $student;
+
+        if (!($user)) {
+            Log::notice("User does not exist on our system.\n");
+            return $this->errorResponse($this->getPredefinedResponse([
+                'type' => 'not-found',
+                'content' => 'user',
+            ]));
+        }
+
+        $dataModel = $admin ? "administrators" : "students";
+
+        $this->validate($request, [
+            'email' => [
+                'bail',
+                'required',
+                'email',
+                Rule::unique($dataModel)->ignore($user),
+            ],
+        ]);
+
+        try {
+            $tokenId = $this->getTokenId($request->bearerToken(), $user);
+
+            if (!($tokenId)) {
+                Log::error("Bearer token is missing and/or user-token did not match.\n");
+                return $this->errorResponse($this->getPredefinedResponse([
+                    'type' => 'default',
+                ]));
+            }
+
+            $user->email = $request->email;
+
+            $user->save();
+
+            Log::info("Successfully updated authenticated user ID " . $user->id . "'s email address. Leaving AccountController emailUpdate...\n");
+            return $this->successResponse("details", $user->email);
+        } catch (\Exception $e) {
+            Log::error("Failed to update authenticated user's email address. " . $e->getMessage() . ".\n");
+            return $this->errorResponse($this->getPredefinedResponse([
+                'type' => 'default',
+            ]));
+        }
+    }
+
+    public function passwordUpdate(Request $request) {
+        Log::info("Entering AccountController passwordUpdate...\n");
+
+        $this->validate($request, [
+            'slug' => [
+                'bail',
+                'required',
+                'regex:/^[^\s\[\]\.\|@\^\\\$\?\*\+\(\)\{\}~!#%&`]+?$/',
+            ],
+            'current_password' => 'bail|required',
+            'password' => 'bail|required|string|min:8|max:20',
+            'password_confirmation' => 'bail|required',
+        ]);
+
+        try {            
+            $admin = $this->getRecord('administrators', $request->slug);
+            $student = $this->getRecord('students', $request->slug);
+            $user = null;
+
+            if (!($admin)) {
+                Log::notice("Administrator does not exist on our system.\n");
+            }
+
+            if (!($student)) {
+                Log::notice("Student does not exist on our system.\n");
+            }
+
+            $user = $admin ? $admin : $student;
+
+            if (!($user)) {
+                Log::notice("User does not exist on our system.\n");
+                return $this->errorResponse($this->getPredefinedResponse([
+                    'type' => 'not-found',
+                    'content' => 'user',
+                ]));
+            }
+
+            $tokenId = $this->getTokenId($request->bearerToken(), $user);
+
+            if (!($tokenId)) {
+                Log::error("Bearer token is missing and/or user-token did not match.\n");
+                return $this->errorResponse($this->getPredefinedResponse([
+                    'type' => 'default',
+                ]));
+            }
+
+            if (!(Hash::check($request->current_password, $user->password))) {
+                Log::error("Current password is incorrect.\n");
+                return $this->errorResponse($this->getPredefinedResponse([
+                    'type' => 'default',
+                ]));
+            }
+
+            $user->password = Hash::make($request->password);
+
+            $user->save();
+
+            Log::info("Successfully updated authenticated user ID " . $user->id . "'s password. Leaving AccountController passwordUpdate...\n");
+
+            // revoke all tokens and re-issue a new one
+            $user->tokens()->delete();
+            $token = $user->createToken('auth_admin_token')->plainTextToken;
+
+            return $this->successResponse("details", [
+                'token' => $token,
+            ]);
+        } catch (\Exception $e) {
+            Log::error("Failed to update authenticated user's password. " . $e->getMessage() . ".\n");
             return $this->errorResponse($this->getPredefinedResponse([
                 'type' => 'default',
             ]));

--- a/database/migrations/2022_06_17_223106_create_administrators_table.php
+++ b/database/migrations/2022_06_17_223106_create_administrators_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('administrators', function (Blueprint $table) {
             $table->id();
             $table->string('first_name');
-            $table->string('middle_name');
+            $table->string('middle_name')->nullable();
             $table->string('last_name');
             $table->string('email')->unique();
             $table->string('password');

--- a/database/migrations/2022_06_17_223112_create_students_table.php
+++ b/database/migrations/2022_06_17_223112_create_students_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('students', function (Blueprint $table) {
             $table->id();
             $table->string('first_name');
-            $table->string('middle_name');
+            $table->string('middle_name')->nullable();
             $table->string('last_name');
             $table->string('student_number')->unique();
             $table->string('email')->unique();

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,9 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::get("/admins", [AccountController::class, "adminGetAll"]);
     Route::post("/admin-register", [AccountController::class, "adminStore"]);
     Route::post("/toggle-admin-status", [AccountController::class, "adminToggleStatus"]);
+    Route::post("/admin-name-update", [AccountController::class, "adminNameUpdate"]);
+    Route::post("/admin-email-update", [AccountController::class, "adminEmailUpdate"]);
+    Route::post("/admin-password-update", [AccountController::class, "adminPasswordUpdate"]);
 
     // Student
     Route::get("/students", [AccountController::class, "studentGetAll"]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,11 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::post("/admin-email-update", [AccountController::class, "adminEmailUpdate"]);
     Route::post("/admin-password-update", [AccountController::class, "adminPasswordUpdate"]);
 
+    // Admin and student
+    Route::post("/name-update", [AccountController::class, "nameUpdate"]);
+    Route::post("/email-update", [AccountController::class, "emailUpdate"]);
+    Route::post("/password-update", [AccountController::class, "passwordUpdate"]);
+
     // Student
     Route::get("/students", [AccountController::class, "studentGetAll"]);
     Route::get("/student", [AccountController::class, "studentGet"]);


### PR DESCRIPTION
- Fixes `student` data mode name update
- Initializes authenticated user's settings when updating name, email address, and password
- Asks for the authenticated user's password when updating the password
- Revokes previous API tokens and reissues a new one